### PR TITLE
[BUGFIX] Prevent wrong classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,10 +36,5 @@
     "typo3/cms": {
       "extension-key": "static_info_tables_pl"
     }
-  },
-  "autoload": {
-    "psr-4": {
-      "SJBR\\StaticInfoTables\\": "Classes/"
-    }
   }
 }


### PR DESCRIPTION
The PSR-4 autloader entry in the `composer.json` create wrong classmap entries.